### PR TITLE
Remove calls to DateTime::getTimestamp()

### DIFF
--- a/life/index.php
+++ b/life/index.php
@@ -49,8 +49,8 @@
 				// class = "week empty past";
 
 
-
-				if ($startDate->getTimestamp() < $today->getTimestamp()) {
+				$diff = $today->diff($startDate);
+				if ($diff->invert == 1) {
                    $weekClassName = "week empty past";
                 } else {
                     $weekClassName = "week empty";

--- a/life/year.php
+++ b/life/year.php
@@ -2,13 +2,15 @@
     include("header.php");
 	include("events.php");
 
-    $date = $_GET["date"];
-    $year = date("Y", strtotime($date));
+    $date = new DateTime($_GET["date"]);
+    $year = $date->format("Y");
 
 	$events = new Events();
 	$eventsForYear = $events->eventsForYear($year);
 
-	$phasesDuringDate = $events->phasesDuringDate(new DateTime($date));
+	// Say dates since the beginning of the year
+	$date->setDate($year, 1, 1);
+	$phasesDuringDate = $events->phasesDuringDate($date);
 ?>
 
 <script src="js/events.js"></script>


### PR DESCRIPTION
We can't use getTimestamp on 32-bit machines, because it will overflow after 2038.
